### PR TITLE
Add & implement ds:Object element

### DIFF
--- a/src/XML/ds/DsObject.php
+++ b/src/XML/ds/DsObject.php
@@ -6,6 +6,7 @@ namespace SimpleSAML\XMLSecurity\XML\ds;
 
 use DOMElement;
 use SimpleSAML\Assert\Assert;
+use SimpleSAML\XML\Constants;
 use SimpleSAML\XML\Exception\InvalidDOMElementException;
 use SimpleSAML\XML\ExtendableElementTrait;
 use SimpleSAML\XMLSecurity\Exception\InvalidArgumentException;
@@ -21,6 +22,9 @@ final class DsObject extends AbstractDsElement
 
     /** @var string */
     public const LOCALNAME = 'Object';
+
+    /** @var string */
+    public const NAMESPACE = Constants::XS_ANY_NS_ANY;
 
     /**
      * The Id.
@@ -159,11 +163,11 @@ final class DsObject extends AbstractDsElement
     public static function fromXML(DOMElement $xml): object
     {
         Assert::same($xml->localName, 'Object', InvalidDOMElementException::class);
-        Assert::same($xml->namespaceURI, Object::NS, InvalidDOMElementException::class);
+        Assert::same($xml->namespaceURI, DSObject::NS, InvalidDOMElementException::class);
 
-        $Id = Object::getAttribute($xml, 'Id');
-        $MimeType = Object::getAttribute($xml, 'MimeType');
-        $Encoding = Object::getAttribute($xml, 'Encoding');
+        $Id = DsObject::getAttribute($xml, 'Id');
+        $MimeType = DsObject::getAttribute($xml, 'MimeType');
+        $Encoding = DsObject::getAttribute($xml, 'Encoding');
 
         $elements = [];
         foreach ($xml->childNodes as $elt) {

--- a/src/XML/ds/DsObject.php
+++ b/src/XML/ds/DsObject.php
@@ -88,6 +88,7 @@ final class DsObject extends AbstractDsElement
      */
     private function setId(?string $Id): void
     {
+        Assert::nullOrValidNCName($Id);
         $this->Id = $Id;
     }
 

--- a/src/XML/ds/DsObject.php
+++ b/src/XML/ds/DsObject.php
@@ -175,6 +175,7 @@ final class DsObject extends AbstractDsElement
         $elements = [];
         foreach ($xml->childNodes as $elt) {
             if (!($elt instanceof DOMElement)) {
+                // @TODO: support mixed content
                 continue;
             }
 

--- a/src/XML/ds/DsObject.php
+++ b/src/XML/ds/DsObject.php
@@ -132,6 +132,7 @@ final class DsObject extends AbstractDsElement
      */
     private function setEncoding(?string $Encoding): void
     {
+        Assert::validURI($Encoding);
         $this->Encoding = $Encoding;
     }
 

--- a/src/XML/ds/DsObject.php
+++ b/src/XML/ds/DsObject.php
@@ -6,6 +6,7 @@ namespace SimpleSAML\XMLSecurity\XML\ds;
 
 use DOMElement;
 use SimpleSAML\Assert\Assert;
+use SimpleSAML\XML\Chunk;
 use SimpleSAML\XML\Constants;
 use SimpleSAML\XML\Exception\InvalidDOMElementException;
 use SimpleSAML\XML\ExtendableElementTrait;

--- a/src/XML/ds/DsObject.php
+++ b/src/XML/ds/DsObject.php
@@ -55,7 +55,7 @@ final class DsObject extends AbstractDsElement
      * @param string|null $Id
      * @param string|null $MimeType
      * @param string|null $Encoding
-     * @param \SimpleSAML\XML\XMLElementInterface[] $elements
+     * @param \SimpleSAML\XML\ElementInterface[] $elements
      */
     public function __construct(
         ?string $Id = null,
@@ -158,12 +158,12 @@ final class DsObject extends AbstractDsElement
      * Convert XML into a ds:Object
      *
      * @param \DOMElement $xml The XML element we should load
-     * @return self
+     * @return static
      *
      * @throws \SimpleSAML\XML\Exception\InvalidDOMElementException
      *   If the qualified name of the supplied element is wrong
      */
-    public static function fromXML(DOMElement $xml): object
+    public static function fromXML(DOMElement $xml): static
     {
         Assert::same($xml->localName, 'Object', InvalidDOMElementException::class);
         Assert::same($xml->namespaceURI, DsObject::NS, InvalidDOMElementException::class);
@@ -181,7 +181,7 @@ final class DsObject extends AbstractDsElement
             $elements[] = new Chunk($elt);
         }
 
-        return new self($Id, $MimeType, $Encoding, $elements);
+        return new static($Id, $MimeType, $Encoding, $elements);
     }
 
 
@@ -207,6 +207,7 @@ final class DsObject extends AbstractDsElement
             $e->setAttribute('Encoding', $this->Encoding);
         }
 
+        /** @psalm-var \SimpleSAML\XML\SerializableElementInterface[] $this->elements */
         foreach ($this->elements as $elt) {
             $elt->toXML($e);
         }

--- a/src/XML/ds/DsObject.php
+++ b/src/XML/ds/DsObject.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\XMLSecurity\XML\ds;
+
+use DOMElement;
+use SimpleSAML\Assert\Assert;
+use SimpleSAML\XML\Exception\InvalidDOMElementException;
+use SimpleSAML\XML\ExtendableElementTrait;
+use SimpleSAML\XMLSecurity\Exception\InvalidArgumentException;
+
+/**
+ * Class representing a ds:Object element.
+ *
+ * @package simplesamlphp/xml-security
+ */
+final class DsObject extends AbstractDsElement
+{
+    use ExtendableElementTrait;
+
+    /** @var string */
+    public const LOCALNAME = 'Object';
+
+    /**
+     * The Id.
+     *
+     * @var string|null
+     */
+    protected ?string $Id;
+
+    /**
+     * The MIME type.
+     *
+     * @var string|null
+     */
+    protected ?string $MimeType;
+
+    /**
+     * The encoding.
+     *
+     * @var string|null
+     */
+    protected ?string $Encoding;
+
+
+    /**
+     * Initialize a ds:Object element.
+     *
+     * @param string|null $Id
+     * @param string|null $MimeType
+     * @param string|null $Encoding
+     * @param \SimpleSAML\XML\XMLElementInterface[] $elements
+     */
+    public function __construct(
+        ?string $Id = null,
+        ?string $MimeType = null,
+        ?string $Encoding = null,
+        array $elements = []
+    ) {
+        $this->setId($Id);
+        $this->setMimeType($MimeType);
+        $this->setEncoding($Encoding);
+        $this->setElements($elements);
+    }
+
+
+    /**
+     * Collect the value of the Id-property
+     *
+     * @return string|null
+     */
+    public function getId(): ?string
+    {
+        return $this->Id;
+    }
+
+
+    /**
+     * Set the value of the Id-property
+     *
+     * @param string $Id
+     */
+    private function setId(?string $Id): void
+    {
+        $this->Id = $Id;
+    }
+
+
+    /**
+     * Collect the value of the MimeType-property
+     *
+     * @return string|null
+     */
+    public function getMimeType(): ?string
+    {
+        return $this->MimeType;
+    }
+
+
+    /**
+     * Set the value of the MimeType-property
+     *
+     * @param string|null $MimeType
+     */
+    private function setMimeType(?string $MimeType): void
+    {
+        $this->MimeType = $MimeType;
+    }
+
+
+    /**
+     * Collect the value of the Encoding-property
+     *
+     * @return string|null
+     */
+    public function getEncoding(): ?string
+    {
+        return $this->Encoding;
+    }
+
+
+    /**
+     * Set the value of the Encoding-property
+     *
+     * @param string|null $Encoding
+     */
+    private function setEncoding(?string $Encoding): void
+    {
+        $this->Encoding = $Encoding;
+    }
+
+
+    /**
+     * Test if an object, at the state it's in, would produce an empty XML-element
+     *
+     * @return bool
+     */
+    public function isEmptyElement(): bool
+    {
+        return (
+            empty($this->elements)
+            && empty($this->Id)
+            && empty($this->MimeType)
+            && empty($this->Encoding)
+        );
+    }
+
+
+    /**
+     * Convert XML into a ds:Object
+     *
+     * @param \DOMElement $xml The XML element we should load
+     * @return self
+     *
+     * @throws \SimpleSAML\XML\Exception\InvalidDOMElementException
+     *   If the qualified name of the supplied element is wrong
+     */
+    public static function fromXML(DOMElement $xml): object
+    {
+        Assert::same($xml->localName, 'Object', InvalidDOMElementException::class);
+        Assert::same($xml->namespaceURI, Object::NS, InvalidDOMElementException::class);
+
+        $Id = Object::getAttribute($xml, 'Id');
+        $MimeType = Object::getAttribute($xml, 'MimeType');
+        $Encoding = Object::getAttribute($xml, 'Encoding');
+
+        $elements = [];
+        foreach ($xml->childNodes as $elt) {
+            if (!($elt instanceof DOMElement)) {
+                continue;
+            }
+
+            $elements[] = new Chunk($elt);
+        }
+
+        return new self($Id, $MimeType, $Encoding, $elements);
+    }
+
+
+    /**
+     * Convert this ds:Object element to XML.
+     *
+     * @param \DOMElement|null $parent The element we should append this ds:Object element to.
+     * @return \DOMElement
+     */
+    public function toXML(DOMElement $parent = null): DOMElement
+    {
+        $e = $this->instantiateParentElement($parent);
+        $e->setAttribute('Id', $this->Id);
+        $e->setAttribute('MimeType', $this->MimeType);
+        $e->setAttribute('Encoding', $this->Encoding);
+
+        foreach ($this->elements as $elt) {
+            $elt->toXML($e);
+        }
+
+        return $e;
+    }
+}

--- a/src/XML/ds/DsObject.php
+++ b/src/XML/ds/DsObject.php
@@ -164,7 +164,7 @@ final class DsObject extends AbstractDsElement
     public static function fromXML(DOMElement $xml): object
     {
         Assert::same($xml->localName, 'Object', InvalidDOMElementException::class);
-        Assert::same($xml->namespaceURI, DSObject::NS, InvalidDOMElementException::class);
+        Assert::same($xml->namespaceURI, DsObject::NS, InvalidDOMElementException::class);
 
         $Id = DsObject::getAttribute($xml, 'Id');
         $MimeType = DsObject::getAttribute($xml, 'MimeType');

--- a/src/XML/ds/DsObject.php
+++ b/src/XML/ds/DsObject.php
@@ -132,7 +132,7 @@ final class DsObject extends AbstractDsElement
      */
     private function setEncoding(?string $Encoding): void
     {
-        Assert::validURI($Encoding);
+        Assert::nullOrValidURI($Encoding);
         $this->Encoding = $Encoding;
     }
 

--- a/src/XML/ds/DsObject.php
+++ b/src/XML/ds/DsObject.php
@@ -192,9 +192,18 @@ final class DsObject extends AbstractDsElement
     public function toXML(DOMElement $parent = null): DOMElement
     {
         $e = $this->instantiateParentElement($parent);
-        $e->setAttribute('Id', $this->Id);
-        $e->setAttribute('MimeType', $this->MimeType);
-        $e->setAttribute('Encoding', $this->Encoding);
+
+        if ($this->Id !== null) {
+            $e->setAttribute('Id', $this->Id);
+        }
+
+        if ($this->MimeType !== null) {
+            $e->setAttribute('MimeType', $this->MimeType);
+        }
+
+        if ($this->Encoding !== null) {
+            $e->setAttribute('Encoding', $this->Encoding);
+        }
 
         foreach ($this->elements as $elt) {
             $elt->toXML($e);

--- a/tests/XML/ds/ObjectTest.php
+++ b/tests/XML/ds/ObjectTest.php
@@ -69,6 +69,7 @@ final class ObjectTest extends TestCase
         $this->assertEquals('abc123', $obj->getId());
         $this->assertEquals('image/png', $obj->getMimeType());
         $this->assertEquals('http://www.w3.org/2000/09/xmldsig#base64', $obj->getEncoding());
+        $this->assertFalse($obj->isEmptyElement());
 
         $objElement = $obj->getElements();
         $objElement = $objElement[0]->getXML();
@@ -77,5 +78,20 @@ final class ObjectTest extends TestCase
             'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
             $objElement->textContent
         );
+    }
+
+
+    /**
+     * Adding an empty Object-element should yield an empty element.
+     */
+    public function testMarshallingEmptyElement(): void
+    {
+        $ds_ns = DsObject::NS;
+        $obj = new DsObject(null, null, null, []);
+        $this->assertEquals(
+            "<ds:Object xmlns:ds=\"$ds_ns\"/>",
+            strval($obj)
+        );
+        $this->assertTrue($obj->isEmptyElement());
     }
 }

--- a/tests/XML/ds/ObjectTest.php
+++ b/tests/XML/ds/ObjectTest.php
@@ -64,6 +64,9 @@ final class ObjectTest extends TestCase
         $this->assertEquals('abc123', $obj->getId());
         $this->assertEquals('image/png', $obj->getMimeType());
         $this->assertEquals('http://www.w3.org/2000/09/xmldsig#base64', $obj->getEncoding());
-        $this->assertEquals('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=', $o->getElements()[0]->textContent);
+        $this->assertEquals(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+            $obj->getElements()[0]->textContent
+        );
     }
 }

--- a/tests/XML/ds/ObjectTest.php
+++ b/tests/XML/ds/ObjectTest.php
@@ -6,7 +6,8 @@ namespace SimpleSAML\XMLSecurity\Test\XML\ds;
 
 use DOMDocument;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\Test\XML\SerializableXMLTestTrait;
+use SimpleSAML\Test\XML\SchemaValidationTestTrait;
+use SimpleSAML\Test\XML\SerializableElementTestTrait;
 use SimpleSAML\XML\Chunk;
 use SimpleSAML\XML\DOMDocumentFactory;
 use SimpleSAML\XMLSecurity\Constants;
@@ -22,7 +23,8 @@ use SimpleSAML\XMLSecurity\XML\ds\DsObject;
  */
 final class ObjectTest extends TestCase
 {
-    use SerializableXMLTestTrait;
+    use SchemaValidationTestTrait;
+    use SerializableElementTestTrait;
 
 
     /**
@@ -30,6 +32,8 @@ final class ObjectTest extends TestCase
     protected function setUp(): void
     {
         $this->testedClass = DsObject::class;
+
+        $this->schema = dirname(dirname(dirname(dirname(__FILE__)))) . '/schemas/xmldsig1-schema.xsd';
 
         $this->xmlRepresentation = DOMDocumentFactory::fromFile(
             dirname(dirname(dirname(dirname(__FILE__)))) . '/tests/resources/xml/ds_Object.xml'

--- a/tests/XML/ds/ObjectTest.php
+++ b/tests/XML/ds/ObjectTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\XMLSecurity\Test\XML\ds;
+
+use DOMDocument;
+use PHPUnit\Framework\TestCase;
+use SimpleSAML\Test\XML\SerializableXMLTestTrait;
+use SimpleSAML\XML\Chunk;
+use SimpleSAML\XML\DOMDocumentFactory;
+use SimpleSAML\XMLSecurity\Constants;
+use SimpleSAML\XMLSecurity\XML\ds\DsObject;
+
+/**
+ * Class \SimpleSAML\XMLSecurity\XML\Test\ds\ObjectTest
+ *
+ * @covers \SimpleSAML\XMLSecurity\XML\ds\AbstractDsElement
+ * @covers \SimpleSAML\XMLSecurity\XML\ds\Object
+ *
+ * @package simplesamlphp/xml-security
+ */
+final class ObjectTest extends TestCase
+{
+    use SerializableXMLTestTrait;
+
+
+    /**
+     */
+    protected function setUp(): void
+    {
+        $this->testedClass = DsObject::class;
+
+        $this->xmlRepresentation = DOMDocumentFactory::fromFile(
+            dirname(dirname(dirname(dirname(__FILE__)))) . '/tests/resources/xml/ds_Object.xml'
+        );
+    }
+
+
+    /**
+     */
+    public function testMarshalling(): void
+    {
+        $obj = new DsObject(
+            'abc123',
+            'image/png',
+            'http://www.w3.org/2000/09/xmldsig#base64',
+            [new Chunk(DOMDocumentFactory::fromString('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=')->documentElement)]
+        );
+
+        $this->assertEquals(
+            $this->xmlRepresentation->saveXML($this->xmlRepresentation->documentElement),
+            strval($obj)
+        );
+    }
+
+
+    /**
+     */
+    public function testUnmarshalling(): void
+    {
+        $obj = DsObject::fromXML($this->xmlRepresentation->documentElement);
+
+        $this->assertEquals('abc123', $obj->getId());
+        $this->assertEquals('image/png', $obj->getMimeType());
+        $this->assertEquals('http://www.w3.org/2000/09/xmldsig#base64', $obj->getEncoding());
+        $this->assertEquals('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=', $o->getElements()[0]->textContent);
+    }
+}

--- a/tests/XML/ds/ObjectTest.php
+++ b/tests/XML/ds/ObjectTest.php
@@ -45,7 +45,12 @@ final class ObjectTest extends TestCase
             'abc123',
             'image/png',
             'http://www.w3.org/2000/09/xmldsig#base64',
-            [$this->xmlRepresentation],
+            [
+                new Chunk(
+                    DOMDocumentFactory::fromString(
+                        '<ssp:data xmlns:ssp="urn:ssp:custom">iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=</ssp:data>'
+                )->documentElement)
+            ],
         );
 
         $this->assertEquals(

--- a/tests/XML/ds/ObjectTest.php
+++ b/tests/XML/ds/ObjectTest.php
@@ -16,7 +16,7 @@ use SimpleSAML\XMLSecurity\XML\ds\DsObject;
  * Class \SimpleSAML\XMLSecurity\XML\Test\ds\ObjectTest
  *
  * @covers \SimpleSAML\XMLSecurity\XML\ds\AbstractDsElement
- * @covers \SimpleSAML\XMLSecurity\XML\ds\Object
+ * @covers \SimpleSAML\XMLSecurity\XML\ds\DsObject
  *
  * @package simplesamlphp/xml-security
  */

--- a/tests/XML/ds/ObjectTest.php
+++ b/tests/XML/ds/ObjectTest.php
@@ -46,7 +46,6 @@ final class ObjectTest extends TestCase
             'image/png',
             'http://www.w3.org/2000/09/xmldsig#base64',
             [$this->xmlRepresentation],
-//            [new Chunk(DOMDocumentFactory::fromString('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=')->documentElement)]
         );
 
         $this->assertEquals(
@@ -65,9 +64,13 @@ final class ObjectTest extends TestCase
         $this->assertEquals('abc123', $obj->getId());
         $this->assertEquals('image/png', $obj->getMimeType());
         $this->assertEquals('http://www.w3.org/2000/09/xmldsig#base64', $obj->getEncoding());
+
+        $objElement = $obj->getElements();
+        $objElement = $objElement[0]->getXML();
+
         $this->assertEquals(
-            '<ssp:data>iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=</ssp:data>',
-            $obj->getElements()[0]->textContent
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+            $objElement->textContent
         );
     }
 }

--- a/tests/XML/ds/ObjectTest.php
+++ b/tests/XML/ds/ObjectTest.php
@@ -45,7 +45,8 @@ final class ObjectTest extends TestCase
             'abc123',
             'image/png',
             'http://www.w3.org/2000/09/xmldsig#base64',
-            [new Chunk(DOMDocumentFactory::fromString('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=')->documentElement)]
+            [$this->xmlRepresentation],
+//            [new Chunk(DOMDocumentFactory::fromString('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=')->documentElement)]
         );
 
         $this->assertEquals(
@@ -65,7 +66,7 @@ final class ObjectTest extends TestCase
         $this->assertEquals('image/png', $obj->getMimeType());
         $this->assertEquals('http://www.w3.org/2000/09/xmldsig#base64', $obj->getEncoding());
         $this->assertEquals(
-            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+            '<ssp:data>iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=</ssp:data>',
             $obj->getElements()[0]->textContent
         );
     }

--- a/tests/resources/xml/ds_Object.xml
+++ b/tests/resources/xml/ds_Object.xml
@@ -1,0 +1,1 @@
+<ds:Object xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="abc123" MimeType="image/png" Encoding="http://www.w3.org/2000/09/xmldsig#base64">iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=</ds:Object>

--- a/tests/resources/xml/ds_Object.xml
+++ b/tests/resources/xml/ds_Object.xml
@@ -1,1 +1,3 @@
-<ds:Object xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="abc123" MimeType="image/png" Encoding="http://www.w3.org/2000/09/xmldsig#base64">iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=</ds:Object>
+<ds:Object xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="abc123" MimeType="image/png" Encoding="http://www.w3.org/2000/09/xmldsig#base64">
+  <ssp:data xmlns:ssp="urn:ssp:custom">iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=</ssp:data>
+</ds:Object>


### PR DESCRIPTION
It appears ComplexType can not only contain other elements (=ComplexContent), but also just textContent (=SimpleContext)
This kinda messes up everything we had so far