### PR TITLE
Update ds:Transforms to limit its support

### DIFF
--- a/src/XML/ds/Transform.php
+++ b/src/XML/ds/Transform.php
@@ -5,110 +5,171 @@ declare(strict_types=1);
 namespace SimpleSAML\XMLSecurity\XML\ds;
 
 use DOMElement;
-use SimpleSAML\Assert\Assert;
-use SimpleSAML\XML\Chunk;
-use SimpleSAML\XML\Exception\InvalidDOMElementException;
+use SimpleSAML\XMLSecurity\Constants as C;
+use SimpleSAML\XMLSecurity\XML\ec\InclusiveNamespaces;
+use Webmozart\Assert\Assert;
 
 /**
- * Class representing a ds:Transform element.
+ * Class representing transforms.
  *
  * @package simplesamlphp/xml-security
  */
-final class Transform extends AbstractDsElement
+class Transform extends AbstractDsElement
 {
-    /** @var string */
-    protected string $Algorithm;
+    /**
+     * The algorithm used for this transform.
+     *
+     * @var string
+     */
+    protected string $algorithm;
 
-    /** @var \SimpleSAML\XML\Chunk[] */
-    protected array $elements = [];
+    /**
+     * An XPath object.
+     *
+     * @var XPath|null
+     */
+    protected XPath $xpath;
+
+    /**
+     * An InclusiveNamespaces object.
+     *
+     * @var InclusiveNamespaces|null
+     */
+    protected InclusiveNamespaces $inclusiveNamespaces;
 
 
     /**
-     * Initialize a ds:Transform
+     * Initialize the Transform element.
      *
-     * @param string $Algorithm
-     * @param \SimpleSAML\XML\Chunk[] $elements
+     * @param string $algorithm
+     * @param XPath|null $xpath
+     * @param InclusiveNamespaces|null $prefixes
      */
     public function __construct(
-        string $Algorithm,
-        array $elements = []
+        string $algorithm,
+        ?XPath $xpath,
+        ?InclusiveNamespaces $inclusiveNamespaces
     ) {
-        $this->setElements($elements);
-        $this->setAlgorithm($Algorithm);
+        $this->setAlgorithm($algorithm);
+        $this->setXPath($xpath);
+        $this->setInclusiveNamespaces($inclusiveNamespaces);
     }
 
 
     /**
+     * Get the algorithm associated with this transform.
+     *
      * @return string
      */
     public function getAlgorithm(): string
     {
-        return $this->Algorithm;
+        return $this->algorithm;
     }
 
 
     /**
-     * @param string $Algorithm
-     * @throws \SimpleSAML\Assert\AssertionFailedException
-     */
-    protected function setAlgorithm(string $Algorithm): void
-    {
-        Assert::notEmpty($Algorithm, 'Cannot set an empty algorithm in ' . static::NS_PREFIX . ':Transform.');
-        $this->Algorithm = $Algorithm;
-    }
-
-
-    /**
-     * Collect the elements
+     * Set the value of the algorithm property.
      *
-     * @return \SimpleSAML\XML\Chunk[]
+     * @param string $algorithm
      */
-    public function getElements(): array
+    private function setAlgorithm(string $algorithm): void
     {
-        return $this->elements;
+        Assert::oneOf(
+            $algorithm,
+            [
+                C::C14N_EXCLUSIVE_WITH_COMMENTS,
+                C::C14N_EXCLUSIVE_WITHOUT_COMMENTS,
+                C::C14N_INCLUSIVE_WITH_COMMENTS,
+                C::C14N_INCLUSIVE_WITHOUT_COMMENTS
+            ],
+            'Unsupported Transform algorithm.'
+        );
     }
 
 
     /**
-     * Set the value of the elements-property
+     * Get the XPath associated with this transform.
      *
-     * @param \SimpleSAML\XML\Chunk[] $elements
-     * @throws \SimpleSAML\Assert\AssertionFailedException if the supplied array contains anything other than Chunk objects
+     * @return XPath|null
      */
-    private function setElements(array $elements): void
+    public function getXPath(): XPath
     {
-        Assert::allIsInstanceOf($elements, Chunk::class);
-
-        $this->elements = $elements;
+        return $this->xpath;
     }
 
 
     /**
-     * Convert XML into a Transform element
+     * Set and validate the XPath object.
      *
-     * @param \DOMElement $xml The XML element we should load
+     * @param XPath|null $XPath
+     */
+    private function setXPath(?XPath $xpath): void
+    {
+        if ($xpath === null) {
+            return;
+        }
+        Assert::eq(
+            $this->algorithm,
+            C::XPATH_URI,
+            'Transform algorithm "' . C::XPATH_URI . '" required if XPath provided.'
+        );
+        $this->xpath = $xpath;
+    }
+
+
+    /**
+     * Get the InclusiveNamespaces associated with this transform.
+     *
+     * @return InclusiveNamespaces|null
+     */
+    public function getInclusiveNamespaces(): array
+    {
+        return $this->inclusiveNamespaces;
+    }
+
+
+    /**
+     * Set and validate the InclusiveNamespaces object.
+     *
+     * @param InclusiveNamespaces|null $inclusiveNamespaces
+     */
+    private function setInclusiveNamespaces(?InclusiveNamespaces $inclusiveNamespaces)
+    {
+        if ($inclusiveNamespaces === null) {
+            return;
+        }
+        Assert::oneOf(
+            $this->algorithm,
+            [
+                C::C14N_INCLUSIVE_WITH_COMMENTS,
+                C::C14N_EXCLUSIVE_WITHOUT_COMMENTS
+            ],
+            'Transform algorithm "' . C::C14N_EXCLUSIVE_WITH_COMMENTS . '" or "' .
+            C::C14N_EXCLUSIVE_WITHOUT_COMMENTS . '" required if InclusiveNamespaces provided.'
+        );
+        $this->inclusiveNamespaces = $inclusiveNamespaces;
+    }
+
+
+    /**
+     * Convert XML into a Transform element.
+     *
+     * @param \DOMElement $xml The XML element we should load.
      * @return self
-     *
-     * @throws \SimpleSAML\XML\Exception\InvalidDOMElementException
-     *   If the qualified name of the supplied element is wrong
      */
     public static function fromXML(DOMElement $xml): object
     {
-        Assert::same($xml->localName, 'Transform', InvalidDOMElementException::class);
-        Assert::same($xml->namespaceURI, Transform::NS, InvalidDOMElementException::class);
+        $alg = self::getAttribute($xml, 'Algorithm');
+        $xpath = XPath::getChildrenOfClass($xml);
+        Assert::maxCount($xpath, 1, 'Only one XPath element supported per Transform.');
+        $prefixes = InclusiveNamespaces::getChildrenOfClass($xml);
+        Assert::maxCount(
+            $prefixes,
+            1,
+            'Only one InclusiveNamespaces element supported per Transform.'
+        );
 
-        $Algorithm = self::getAttribute($xml, 'Algorithm');
-
-        $elements = [];
-        foreach ($xml->childNodes as $element) {
-            if (!($element instanceof DOMElement)) {
-                continue;
-            }
-
-            $elements[] = new Chunk($element);
-        }
-
-        return new self($Algorithm, $elements);
+        return new self($alg, array_pop($xpath), array_pop($prefixes));
     }
 
 
@@ -121,10 +182,20 @@ final class Transform extends AbstractDsElement
     public function toXML(DOMElement $parent = null): DOMElement
     {
         $e = $this->instantiateParentElement($parent);
-        $e->setAttribute('Algorithm', $this->Algorithm);
 
-        foreach ($this->elements as $element) {
-            $e->appendChild($e->ownerDocument->importNode($element->getXML(), true));
+        $e->setAttribute('Algorithm', $this->algorithm);
+
+        switch ($this->algorithm) {
+            case C::XPATH_URI:
+                if ($this->xpath !== null) {
+                    $this->xpath->toXML($e);
+                }
+                break;
+            case C::C14N_EXCLUSIVE_WITH_COMMENTS:
+            case C::C14N_EXCLUSIVE_WITHOUT_COMMENTS:
+                if ($this->inclusiveNamespaces !== null) {
+                    $this->inclusiveNamespaces->toXML($e);
+                }
         }
 
         return $e;

--- a/src/XML/ds/Transform.php
+++ b/src/XML/ds/Transform.php
@@ -83,7 +83,7 @@ class Transform extends AbstractDsElement
      *
      * @return XPath|null
      */
-    public function getXPath(): XPath
+    public function getXPath(): ?XPath
     {
         return $this->xpath;
     }
@@ -113,7 +113,7 @@ class Transform extends AbstractDsElement
      *
      * @return InclusiveNamespaces|null
      */
-    public function getInclusiveNamespaces(): array
+    public function getInclusiveNamespaces(): ?InclusiveNamespaces
     {
         return $this->inclusiveNamespaces;
     }

--- a/src/XML/ds/Transform.php
+++ b/src/XML/ds/Transform.php
@@ -28,14 +28,14 @@ class Transform extends AbstractDsElement
      *
      * @var XPath|null
      */
-    protected XPath $xpath;
+    protected ?XPath $xpath = null;
 
     /**
      * An InclusiveNamespaces object.
      *
      * @var InclusiveNamespaces|null
      */
-    protected InclusiveNamespaces $inclusiveNamespaces;
+    protected ?InclusiveNamespaces $inclusiveNamespaces = null;
 
 
     /**
@@ -47,8 +47,8 @@ class Transform extends AbstractDsElement
      */
     public function __construct(
         string $algorithm,
-        ?XPath $xpath,
-        ?InclusiveNamespaces $inclusiveNamespaces
+        ?XPath $xpath = null,
+        ?InclusiveNamespaces $inclusiveNamespaces = null
     ) {
         $this->setAlgorithm($algorithm);
         $this->setXPath($xpath);
@@ -74,16 +74,7 @@ class Transform extends AbstractDsElement
      */
     private function setAlgorithm(string $algorithm): void
     {
-        Assert::oneOf(
-            $algorithm,
-            [
-                C::C14N_EXCLUSIVE_WITH_COMMENTS,
-                C::C14N_EXCLUSIVE_WITHOUT_COMMENTS,
-                C::C14N_INCLUSIVE_WITH_COMMENTS,
-                C::C14N_INCLUSIVE_WITHOUT_COMMENTS
-            ],
-            'Unsupported Transform algorithm.'
-        );
+        $this->algorithm = $algorithm;
     }
 
 

--- a/src/XML/ds/XPath.php
+++ b/src/XML/ds/XPath.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace SimpleSAML\XMLSecurity\XML\ds;
 
-use SimpleSAML\XML\XMLStringElementTrait;
+use DOMElement;
+use SimpleSAML\XML\Exception\InvalidDOMElementException;
+use Webmozart\Assert\Assert;
 
 /**
  * Class implementing the XPath element.
@@ -13,5 +15,124 @@ use SimpleSAML\XML\XMLStringElementTrait;
  */
 class XPath extends AbstractDsElement
 {
-    use XMLStringElementTrait;
+    /**
+     * The XPath expression.
+     *
+     * @var string
+     */
+    protected string $expression;
+
+    /**
+     * A key-value array with namespaces, indexed by the prefixes used in the XPath expression.
+     *
+     * @var string[]
+     */
+    protected array $namespaces = [];
+
+
+    /**
+     * Construct an XPath element.
+     *
+     * @param string $expression The XPath expression itself.
+     * @param string[] $namespaces A key - value array with namespace definitions.
+     */
+    public function __construct(string $expression, array $namespaces = null)
+    {
+        $this->setExpression($expression);
+        $this->setNamespaces($namespaces);
+    }
+
+
+    /**
+     * Get the actual XPath expression.
+     *
+     * @return string
+     */
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+
+
+    /**
+     * Set the xpath expression itself.
+     *
+     * @param string $expression
+     */
+    private function setExpression(string $expression): void
+    {
+        $this->expression = $expression;
+    }
+
+
+    /**
+     * Get the list of namespaces used in this XPath expression, with their corresponding prefix as
+     * the keys of each element in the array.
+     *
+     * @return string[]
+     */
+    public function getNamespaces(): array
+    {
+        return $this->namespaces;
+    }
+
+
+    /**
+     * Set the list of namespaces used in this XPath expression.
+     *
+     * @param string[] $namespaces
+     */
+    private function setNamespaces(?array $namespaces): void
+    {
+        if ($namespaces === null) {
+            return;
+        }
+        Assert::allString($namespaces);
+        Assert::allString(array_keys($namespaces));
+        $this->namespaces = $namespaces;
+    }
+
+
+    /**
+     * Convert XML into a class instance
+     *
+     * @param DOMElement $xml
+     * @return self
+     *
+     * @throws \SimpleSAML\XML\Exception\InvalidDOMElementException
+     *   If the qualified name of the supplied element is wrong
+     */
+    public static function fromXML(DOMElement $xml): object
+    {
+        Assert::same($xml->localName, 'XPath', InvalidDOMElementException::class);
+        Assert::same($xml->namespaceURI, self::NS, InvalidDOMElementException::class);
+
+        $namespaces = [];
+        $xpath = new \DOMXPath($xml->ownerDocument);
+        /** @var \DOMNode $ns */
+        foreach ($xpath->query('namespace::*', $xml) as $ns) {
+            if ($xml->getAttributeNode($ns->nodeName)) {
+                $namespaces[str_replace('xmlns:', '', $ns->nodeName)] =
+                    $xml->getAttribute($ns->nodeName);
+            }
+        }
+
+        return new self($xml->textContent, $namespaces);
+    }
+
+
+    /**
+     * @param DOMElement|null $parent
+     * @return DOMElement
+     */
+    public function toXML(DOMElement $parent = null): DOMElement
+    {
+        $e = $this->instantiateParentElement($parent);
+        $e->textContent = $this->expression;
+
+        foreach ($this->namespaces as $prefix => $namespace) {
+            $e->setAttribute('xmlns:' . $prefix, $namespace);
+        }
+        return $e;
+    }
 }

--- a/src/XML/ds/XPath.php
+++ b/src/XML/ds/XPath.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\XMLSecurity\XML\ds;
+
+use SimpleSAML\XML\XMLStringElementTrait;
+
+/**
+ * Class implementing the XPath element.
+ *
+ * @package simplesamlphp/xml-security
+ */
+class XPath extends AbstractDsElement
+{
+    use XMLStringElementTrait;
+}

--- a/src/XML/ec/AbstractEcElement.php
+++ b/src/XML/ec/AbstractEcElement.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\XMLSecurity\XML\ec;
+
+use SimpleSAML\XML\AbstractXMLElement;
+use SimpleSAML\XMLSecurity\Constants;
+
+
+/**
+ * Abstract class to be implemented by all the classes in this namespace
+
+ * @package simplesamlphp/xml-security
+ */
+abstract class AbstractEcElement extends AbstractXMLElement
+{
+    /** @var string */
+    public const NS = Constants::C14N_EXCLUSIVE_WITHOUT_COMMENTS;
+
+    /** @var string */
+    public const NS_PREFIX = 'ec';
+
+
+    /**
+     * Get the namespace for the element.
+     *
+     * @return string
+     */
+    public static function getNamespaceURI(): string
+    {
+        return static::NS;
+    }
+
+
+    /**
+     * Get the namespace prefix for the element.
+     *
+     * @return string
+     */
+    public static function getNamespacePrefix(): string
+    {
+        return static::NS_PREFIX;
+    }
+}

--- a/src/XML/ec/InclusiveNamespaces.php
+++ b/src/XML/ec/InclusiveNamespaces.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\XMLSecurity\XML\ec;
+
+use DOMElement;
+use Webmozart\Assert\Assert;
+
+/**
+ * Class implementing InclusiveNamespaces
+ *
+ * @package simplesamlphp/xml-security
+ */
+class InclusiveNamespaces extends AbstractEcElement
+{
+    /** @var string[] */
+    protected array $prefixes;
+
+
+    /**
+     * Initialize the InclusiveNamespaces element.
+     *
+     * @param string[] $prefixes
+     */
+    public function __construct(array $prefixes)
+    {
+        $this->setPrefixes($prefixes);
+    }
+
+
+    /**
+     * Get the prefixes specified by this element.
+     *
+     * @return string[]
+     */
+    public function getPrefixes(): array
+    {
+        return $this->prefixes;
+    }
+
+
+    /**
+     * Set the prefixes to specify in this element.
+     *
+     * @param string[] $prefixes
+     */
+    private function setPrefixes(array $prefixes): void
+    {
+        Assert::allString($prefixes, 'Can only add string InclusiveNamespaces prefixes.');
+        $this->prefixes = $prefixes;
+    }
+
+
+    /**
+     * Convert XML into an InclusiveNamespaces element.
+     *
+     * @param \DOMElement $xml The XML element we should load.
+     * @return self
+     */
+    public static function fromXML(DOMElement $xml): object
+    {
+        $prefixes = self::getAttribute($xml, 'PrefixList', '');
+
+        return new self(explode(' ', $prefixes));
+    }
+
+    /**
+     * Convert this InclusiveNamespaces to XML.
+     *
+     * @param \DOMElement|null $parent The element we should append this InclusiveNamespaces to.
+     * @return \DOMElement
+     */
+    public function toXML(DOMElement $parent = null): DOMElement
+    {
+        $e = $this->instantiateParentElement($parent);
+
+        if (!empty($this->prefixes)) {
+            $e->setAttribute('PrefixList', join(' ', $this->prefixes));
+        }
+
+        return $e;
+    }
+}

--- a/tests/XML/ds/ReferenceTest.php
+++ b/tests/XML/ds/ReferenceTest.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace SimpleSAML\XMLSecurity\Test\XML\ds;
 
-use DOMDocument;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Test\XML\SerializableXMLTestTrait;
 use SimpleSAML\XML\DOMDocumentFactory;
-use SimpleSAML\XML\Chunk;
-use SimpleSAML\XML\Utils as XMLUtils;
 use SimpleSAML\XMLSecurity\Constants;
 use SimpleSAML\XMLSecurity\XML\ds\DigestMethod;
 use SimpleSAML\XMLSecurity\XML\ds\DigestValue;

--- a/tests/XML/ds/SignedInfoTest.php
+++ b/tests/XML/ds/SignedInfoTest.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace SimpleSAML\XMLSecurity\Test\XML\ds;
 
-use DOMDocument;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Test\XML\SerializableXMLTestTrait;
 use SimpleSAML\XML\DOMDocumentFactory;
-use SimpleSAML\XML\Chunk;
-use SimpleSAML\XML\Utils as XMLUtils;
 use SimpleSAML\XMLSecurity\Constants;
 use SimpleSAML\XMLSecurity\XML\ds\CanonicalizationMethod;
 use SimpleSAML\XMLSecurity\XML\ds\Reference;

--- a/tests/XML/ds/TransformTest.php
+++ b/tests/XML/ds/TransformTest.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace SimpleSAML\XMLSecurity\Test\XML\ds;
 
-use DOMDocument;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\Constants;
+use SimpleSAML\XMLSecurity\Constants as C;
 use SimpleSAML\Test\XML\SerializableXMLTestTrait;
 use SimpleSAML\XML\DOMDocumentFactory;
-use SimpleSAML\XML\Chunk;
-use SimpleSAML\XML\Utils as XMLUtils;
 use SimpleSAML\XMLSecurity\XML\ds\Transform;
+use SimpleSAML\XMLSecurity\XML\ds\XPath;
 
 /**
  * Class \SimpleSAML\XMLSecurity\Test\XML\ds\TransformTest
@@ -43,10 +41,8 @@ final class TransformTest extends TestCase
     public function testMarshalling(): void
     {
         $transform = new Transform(
-            'http://www.w3.org/TR/1999/REC-xpath-19991116',
-            [
-                new Chunk(DOMDocumentFactory::fromString('<ds:XPath>count(//. | //@* | //namespace::*)</ds:XPath>')->documentElement)
-            ],
+            C::XPATH_URI,
+            new XPath('count(//. | //@* | //namespace::*)')
         );
 
         $this->assertEquals(
@@ -61,12 +57,11 @@ final class TransformTest extends TestCase
     public function testUnmarshalling(): void
     {
         $transform = Transform::fromXML($this->xmlRepresentation->documentElement);
-        $this->assertEquals('http://www.w3.org/TR/1999/REC-xpath-19991116', $transform->getAlgorithm());
+        $this->assertEquals(C::XPATH_URI, $transform->getAlgorithm());
 
-        $elements = $transform->getElements();
-        $this->assertCount(1, $elements);
+        $xpath = $transform->getXPath();
 
-        $this->assertInstanceOf(Chunk::class, $elements[0]);
+        $this->assertInstanceOf(XPath::class, $xpath);
 
         $this->assertEquals(
             $this->xmlRepresentation->saveXML($this->xmlRepresentation->documentElement),

--- a/tests/XML/ds/TransformTest.php
+++ b/tests/XML/ds/TransformTest.php
@@ -10,6 +10,7 @@ use SimpleSAML\Test\XML\SerializableXMLTestTrait;
 use SimpleSAML\XML\DOMDocumentFactory;
 use SimpleSAML\XMLSecurity\XML\ds\Transform;
 use SimpleSAML\XMLSecurity\XML\ds\XPath;
+use SimpleSAML\XMLSecurity\XML\ec\InclusiveNamespaces;
 
 /**
  * Class \SimpleSAML\XMLSecurity\Test\XML\ds\TransformTest
@@ -47,6 +48,25 @@ final class TransformTest extends TestCase
 
         $this->assertEquals(
             $this->xmlRepresentation->saveXML($this->xmlRepresentation->documentElement),
+            strval($transform)
+        );
+
+        $transform = new Transform(
+            C::C14N_EXCLUSIVE_WITHOUT_COMMENTS,
+            null,
+            new InclusiveNamespaces(["dsig", "soap", "#default"])
+        );
+
+
+        $this->assertInstanceOf(InclusiveNamespaces::class, $transform->getInclusiveNamespaces());
+        $this->assertNull($transform->getXPath());
+
+        $xmlRepresentation = DOMDocumentFactory::fromFile(
+            dirname(dirname(dirname(__FILE__))) .
+            '/resources/xml/ds_Transform_InclusiveNamespaces.xml'
+        );
+        $this->assertEquals(
+            $xmlRepresentation->saveXML($xmlRepresentation->documentElement),
             strval($transform)
         );
     }

--- a/tests/XML/ds/TransformsTest.php
+++ b/tests/XML/ds/TransformsTest.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Test\SAML2\XML\ds;
 
-use DOMDocument;
 use PHPUnit\Framework\TestCase;
-use SimpleSAML\SAML2\Constants;
+use SimpleSAML\XMLSecurity\Constants as C;
 use SimpleSAML\Test\XML\SerializableXMLTestTrait;
 use SimpleSAML\XML\DOMDocumentFactory;
-use SimpleSAML\XML\Chunk;
-use SimpleSAML\XML\Utils as XMLUtils;
 use SimpleSAML\XMLSecurity\XML\ds\Transform;
 use SimpleSAML\XMLSecurity\XML\ds\Transforms;
+use SimpleSAML\XMLSecurity\XML\ds\XPath;
 
 /**
  * Class \SimpleSAML\XMLSecurity\Test\XML\ds\TransformsTest
@@ -46,14 +44,11 @@ final class TransformsTest extends TestCase
         $transforms = new Transforms(
             [
                 new Transform(
-                    'http://www.w3.org/TR/1999/REC-xpath-19991116',
-                    [
-                        new Chunk(
-                            DOMDocumentFactory::fromString(
-                                '<ds:XPath xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">self::xenc:CipherValue[@Id="example1"]</ds:XPath>'
-                            )->documentElement
-                        )
-                    ]
+                    C::XPATH_URI,
+                    new XPath(
+                        'self::xenc:CipherValue[@Id="example1"]',
+                        ['xenc' => 'http://www.w3.org/2001/04/xmlenc#']
+                    ),
                 )
             ]
         );
@@ -74,12 +69,10 @@ final class TransformsTest extends TestCase
         $this->assertCount(1, $transform);
 
         $transform = array_pop($transform);
-        $this->assertEquals('http://www.w3.org/TR/1999/REC-xpath-19991116', $transform->getAlgorithm());
+        $this->assertEquals(C::XPATH_URI, $transform->getAlgorithm());
 
-        $elements = $transform->getElements();
-        $this->assertCount(1, $elements);
-
-        $this->assertInstanceOf(Chunk::class, $elements[0]);
+        $xpath = $transform->getXPath();
+        $this->assertInstanceOf(XPath::class, $xpath);
 
         $this->assertEquals(
             $this->xmlRepresentation->saveXML($this->xmlRepresentation->documentElement),

--- a/tests/XML/ds/XPathTest.php
+++ b/tests/XML/ds/XPathTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\XMLSecurity\Test\XML\ds;
+
+use PHPUnit\Framework\TestCase;
+use SimpleSAML\Test\XML\SerializableXMLTestTrait;
+use SimpleSAML\XML\DOMDocumentFactory;
+use SimpleSAML\XMLSecurity\XML\ds\XPath;
+
+/**
+ * Class \SimpleSAML\XMLSecurity\Test\XML\ds\XPathTest
+ *
+ * @covers \SimpleSAML\XMLSecurity\XML\ds\XPath
+ *
+ * @package simplesamlphp/xml-security
+ */
+class XPathTest extends TestCase
+{
+    use SerializableXMLTestTrait;
+
+
+    /**
+     */
+    public function setUp(): void
+    {
+        $this->testedClass = XPath::class;
+
+        $this->xmlRepresentation = DOMDocumentFactory::fromFile(
+            dirname(dirname(dirname(__FILE__))) . '/resources/xml/ds_XPath.xml'
+        );
+    }
+
+
+    public function testMarshalling(): void
+    {
+        $xpath = new XPath(
+            'self::xenc:CipherValue[@Id="example1"]',
+            [
+                'xenc' => 'http://www.w3.org/2001/04/xmlenc#'
+            ]
+        );
+
+        $this->assertEquals('self::xenc:CipherValue[@Id="example1"]', $xpath->getExpression());
+        $namespaces = $xpath->getNamespaces();
+        $this->assertCount(1, $namespaces);
+        $this->assertArrayHasKey('xenc', $namespaces);
+        $this->assertEquals('http://www.w3.org/2001/04/xmlenc#', $namespaces['xenc']);
+
+        $this->assertEquals(
+            $this->xmlRepresentation->saveXML($this->xmlRepresentation->documentElement),
+            strval($xpath)
+        );
+    }
+
+
+    /**
+     */
+    public function testUnmarshalling(): void
+    {
+        $xpath = XPath::fromXML($this->xmlRepresentation->documentElement);
+        $this->assertEquals('self::xenc:CipherValue[@Id="example1"]', $xpath->getExpression());
+        $namespaces = $xpath->getNamespaces();
+        $this->assertCount(2, $namespaces);
+        $this->assertEquals('xenc', array_keys($namespaces)[0]);
+        $this->assertEquals('ds', array_keys($namespaces)[1]);
+
+
+        $this->assertEquals(
+            $this->xmlRepresentation->saveXML($this->xmlRepresentation->documentElement),
+            strval($xpath)
+        );
+    }
+
+}

--- a/tests/XML/ec/InclusiveNamespacesTest.php
+++ b/tests/XML/ec/InclusiveNamespacesTest.php
@@ -7,7 +7,6 @@ namespace SimpleSAML\XMLSecurity\Test\XML\ec;
 use SimpleSAML\Test\XML\SerializableXMLTestTrait;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\XML\DOMDocumentFactory;
-use SimpleSAML\XMLSecurity\XML\ds\Transforms;
 use SimpleSAML\XMLSecurity\XML\ec\InclusiveNamespaces;
 
 /**
@@ -26,7 +25,7 @@ class InclusiveNamespacesTest extends TestCase
      */
     public function setUp(): void
     {
-        $this->testedClass = Transforms::class;
+        $this->testedClass = InclusiveNamespaces::class;
 
         $this->xmlRepresentation = DOMDocumentFactory::fromFile(
             dirname(dirname(dirname(__FILE__))) . '/resources/xml/ec_InclusiveNamespaces.xml'

--- a/tests/XML/ec/InclusiveNamespacesTest.php
+++ b/tests/XML/ec/InclusiveNamespacesTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\XMLSecurity\Test\XML\ec;
+
+use SimpleSAML\Test\XML\SerializableXMLTestTrait;
+use PHPUnit\Framework\TestCase;
+use SimpleSAML\XML\DOMDocumentFactory;
+use SimpleSAML\XMLSecurity\XML\ds\Transforms;
+use SimpleSAML\XMLSecurity\XML\ec\InclusiveNamespaces;
+
+/**
+ * Class \SimpleSAML\XMLSecurity\Test\XML\ec\InclusiveNamespacesTest
+ *
+ * @covers \SimpleSAML\XMLSecurity\XML\ec\InclusiveNamespaces
+ *
+ * @package simplesamlphp/xml-security
+ */
+class InclusiveNamespacesTest extends TestCase
+{
+    use SerializableXMLTestTrait;
+
+
+    /**
+     */
+    public function setUp(): void
+    {
+        $this->testedClass = Transforms::class;
+
+        $this->xmlRepresentation = DOMDocumentFactory::fromFile(
+            dirname(dirname(dirname(__FILE__))) . '/resources/xml/ec_InclusiveNamespaces.xml'
+        );
+    }
+
+
+    public function testMarshalling(): void
+    {
+        $inclusiveNamespaces = new InclusiveNamespaces(["dsig", "soap", "#default"]);
+
+        $this->assertCount(3, $inclusiveNamespaces->getPrefixes());
+        $this->assertEquals("dsig", $inclusiveNamespaces->getPrefixes()[0]);
+        $this->assertEquals("soap", $inclusiveNamespaces->getPrefixes()[1]);
+        $this->assertEquals("#default", $inclusiveNamespaces->getPrefixes()[2]);
+
+        $this->assertEquals(
+            $this->xmlRepresentation->saveXML($this->xmlRepresentation->documentElement),
+            strval($inclusiveNamespaces)
+        );
+    }
+
+
+    /**
+     */
+    public function testUnmarshalling(): void
+    {
+        $inclusiveNamespaces = InclusiveNamespaces::fromXML(
+            $this->xmlRepresentation->documentElement
+        );
+        $prefixes = $inclusiveNamespaces->getPrefixes();
+        $this->assertCount(3, $prefixes);
+
+        $this->assertEquals('dsig', $prefixes[0]);
+        $this->assertEquals('soap', $prefixes[1]);
+        $this->assertEquals('#default', $prefixes[2]);
+
+
+        $this->assertEquals(
+            $this->xmlRepresentation->saveXML($this->xmlRepresentation->documentElement),
+            strval($inclusiveNamespaces)
+        );
+    }
+}

--- a/tests/XML/xenc/CipherReferenceTest.php
+++ b/tests/XML/xenc/CipherReferenceTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace SimpleSAML\XMLSecurity\Test\XML\xenc;
 
-use DOMDocument;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Test\XML\SerializableXMLTestTrait;
 use SimpleSAML\XML\DOMDocumentFactory;
-use SimpleSAML\XML\Utils as XMLUtils;
+use SimpleSAML\XMLSecurity\Constants as C;
+use SimpleSAML\XMLSecurity\XML\ds\Transform;
 use SimpleSAML\XMLSecurity\XML\ds\Transforms;
+use SimpleSAML\XMLSecurity\XML\ds\XPath;
 use SimpleSAML\XMLSecurity\XML\xenc\CipherReference;
-use SimpleSAML\XMLSecurity\XMLSecurityDSig;
 
 /**
  * Class \SimpleSAML\XMLSecurity\Test\XML\xenc\CipherReferenceTest
@@ -26,8 +26,8 @@ final class CipherReferenceTest extends TestCase
 {
     use SerializableXMLTestTrait;
 
-    /** @var \DOMDocument $transforms */
-    private DOMDocument $transforms;
+    /** @var \SimpleSAML\XMLSecurity\XML\ds\Transforms $transforms */
+    private Transforms $transforms;
 
 
     /**
@@ -40,11 +40,9 @@ final class CipherReferenceTest extends TestCase
             dirname(dirname(dirname(dirname(__FILE__)))) . '/tests/resources/xml/xenc_CipherReference.xml'
         );
 
-        $dsNamespace = XMLSecurityDSig::XMLDSIGNS;
-
-        $this->transforms = DOMDocumentFactory::fromFile(
-            dirname(dirname(dirname(dirname(__FILE__)))) . '/tests/resources/xml/ds_Transforms.xml'
-        );
+        $xpath = new XPath('self::xenc:CipherValue[@Id="example1"]');
+        $transform = new Transform(C::XPATH_URI, $xpath);
+        $this->transforms = new Transforms([$transform]);
     }
 
 
@@ -55,7 +53,7 @@ final class CipherReferenceTest extends TestCase
      */
     public function testMarshalling(): void
     {
-        $cipherReference = new CipherReference('#Cipher_VALUE_ID', [Transforms::fromXML($this->transforms->documentElement)]);
+        $cipherReference = new CipherReference('#Cipher_VALUE_ID', [$this->transforms]);
 
         $this->assertEquals(
             $this->xmlRepresentation->saveXML($this->xmlRepresentation->documentElement),
@@ -77,7 +75,7 @@ final class CipherReferenceTest extends TestCase
 
         $references = $cipherReference->getElements();
         $this->assertCount(1, $references);
-        $this->assertEquals($this->transforms, $references[0]->toXML());
+        $this->assertEquals($this->transforms, $references[0]);
 
         $this->assertEquals(
             $this->xmlRepresentation->saveXML($this->xmlRepresentation->documentElement),

--- a/tests/XML/xenc/DataReferenceTest.php
+++ b/tests/XML/xenc/DataReferenceTest.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace SimpleSAML\XMLSecurity\Test\XML\xenc;
 
-use DOMDocument;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Test\XML\SerializableXMLTestTrait;
 use SimpleSAML\XML\DOMDocumentFactory;
+use SimpleSAML\XMLSecurity\Constants as C;
+use SimpleSAML\XMLSecurity\XML\ds\Transform;
 use SimpleSAML\XMLSecurity\XML\ds\Transforms;
+use SimpleSAML\XMLSecurity\XML\ds\XPath;
 use SimpleSAML\XMLSecurity\XML\xenc\DataReference;
-use SimpleSAML\XMLSecurity\XMLSecurityDSig;
 
 /**
  * Class \SimpleSAML\XMLSecurity\Test\XML\xenc\DataReferenceTest
@@ -47,15 +48,13 @@ final class DataReferenceTest extends TestCase
         $dataReference = new DataReference(
             '#Encrypted_DATA_ID',
             [
-                Transforms::fromXML(
-                    DOMDocumentFactory::fromString(<<<XML
-    <ds:Transforms xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-      <ds:Transform Algorithm="http://www.w3.org/TR/1999/REC-xpath-19991116">
-        <ds:XPath xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">self::xenc:EncryptedData[@Id="example1"]</ds:XPath>
-      </ds:Transform>
-    </ds:Transforms>
-XML
-                    )->documentElement
+                new Transforms(
+                    [
+                        new Transform(
+                            C::XPATH_URI,
+                            new XPath('self::xenc:EncryptedData[@Id="example1"]')
+                        )
+                    ]
                 )
             ]
         );

--- a/tests/XML/xenc/KeyReferenceTest.php
+++ b/tests/XML/xenc/KeyReferenceTest.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace SimpleSAML\XMLSecurity\Test\XML\xenc;
 
-use DOMDocument;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Test\XML\SerializableXMLTestTrait;
 use SimpleSAML\XML\DOMDocumentFactory;
+use SimpleSAML\XMLSecurity\Constants as C;
+use SimpleSAML\XMLSecurity\XML\ds\Transform;
 use SimpleSAML\XMLSecurity\XML\ds\Transforms;
+use SimpleSAML\XMLSecurity\XML\ds\XPath;
 use SimpleSAML\XMLSecurity\XML\xenc\KeyReference;
-use SimpleSAML\XMLSecurity\XMLSecurityDSig;
 
 /**
  * Class \SimpleSAML\XMLSecurity\Test\XML\xenc\KeyReferenceTest
@@ -48,15 +49,13 @@ final class KeyReferenceTest extends TestCase
         $keyReference = new KeyReference(
             '#Encrypted_KEY_ID',
             [
-                Transforms::fromXML(
-                    DOMDocumentFactory::fromString(<<<XML
-    <ds:Transforms xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-      <ds:Transform Algorithm="http://www.w3.org/TR/1999/REC-xpath-19991116">
-        <ds:XPath xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">self::xenc:EncryptedKey[@Id="example1"]</ds:XPath>
-      </ds:Transform>
-    </ds:Transforms>
-XML
-                    )->documentElement
+                new Transforms(
+                    [
+                        new Transform(
+                            C::XPATH_URI,
+                            new XPath('self::xenc:EncryptedKey[@Id="example1"]')
+                        )
+                    ]
                 )
             ]
         );

--- a/tests/XML/xenc/ReferenceListTest.php
+++ b/tests/XML/xenc/ReferenceListTest.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace SimpleSAML\XMLSecurity\Test\XML\xenc;
 
-use DOMDocument;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Test\XML\SerializableXMLTestTrait;
-use SimpleSAML\XML\Chunk;
 use SimpleSAML\XML\DOMDocumentFactory;
+use SimpleSAML\XMLSecurity\Constants as C;
+use SimpleSAML\XMLSecurity\XML\ds\Transform;
 use SimpleSAML\XMLSecurity\XML\ds\Transforms;
+use SimpleSAML\XMLSecurity\XML\ds\XPath;
 use SimpleSAML\XMLSecurity\XML\xenc\DataReference;
 use SimpleSAML\XMLSecurity\XML\xenc\KeyReference;
 use SimpleSAML\XMLSecurity\XML\xenc\ReferenceList;
-use SimpleSAML\XMLSecurity\XMLSecurityDSig;
 
 /**
  * Class \SimpleSAML\XMLSecurity\Test\XML\xenc\ReferenceListTest
@@ -47,40 +47,21 @@ final class ReferenceListTest extends TestCase
      */
     public function testMarshalling(): void
     {
+        $transformData = new Transform(
+            C::XPATH_URI,
+            new XPath('self::xenc:EncryptedData[@Id="example1"]')
+        );
+        $transformKey = new Transform(
+            C::XPATH_URI,
+            new XPath('self::xenc:EncryptedKey[@Id="example1"]')
+        );
+
         $referenceList = new ReferenceList(
             [
-                new DataReference(
-                    '#Encrypted_DATA_ID',
-                    [
-                        Transforms::fromXML(
-                            DOMDocumentFactory::fromString(<<<XML
-    <ds:Transforms xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-      <ds:Transform Algorithm="http://www.w3.org/TR/1999/REC-xpath-19991116">
-        <ds:XPath xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">self::xenc:EncryptedData[@Id="example1"]</ds:XPath>
-      </ds:Transform>
-    </ds:Transforms>
-XML
-                            )->documentElement
-                        )
-                    ]
-                ),
+                new DataReference('#Encrypted_DATA_ID', [new Transforms([$transformData])])
             ],
             [
-                new KeyReference(
-                    '#Encrypted_KEY_ID',
-                    [
-                        Transforms::fromXML(
-                            DOMDocumentFactory::fromString(<<<XML
-    <ds:Transforms xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-      <ds:Transform Algorithm="http://www.w3.org/TR/1999/REC-xpath-19991116">
-        <ds:XPath xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">self::xenc:EncryptedKey[@Id="example1"]</ds:XPath>
-      </ds:Transform>
-    </ds:Transforms>
-XML
-                            )->documentElement
-                        )
-                    ]
-                )
+                new KeyReference('#Encrypted_KEY_ID', [new Transforms([$transformKey])])
             ]
         );
 

--- a/tests/resources/xml/ds_Transform_InclusiveNamespaces.xml
+++ b/tests/resources/xml/ds_Transform_InclusiveNamespaces.xml
@@ -1,0 +1,4 @@
+<ds:Transform xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+  <ec:InclusiveNamespaces PrefixList="dsig soap #default"
+    xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+</ds:Transform>

--- a/tests/resources/xml/ds_XPath.xml
+++ b/tests/resources/xml/ds_XPath.xml
@@ -1,0 +1,1 @@
+<ds:XPath xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">self::xenc:CipherValue[@Id="example1"]</ds:XPath>

--- a/tests/resources/xml/ec_InclusiveNamespaces.xml
+++ b/tests/resources/xml/ec_InclusiveNamespaces.xml
@@ -1,0 +1,2 @@
+<ec:InclusiveNamespaces PrefixList="dsig soap #default"
+  xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#"/>


### PR DESCRIPTION
This PR adds explicit support for `ds:XPath` and `ec:InclusiveNamespaces`, which are the only things that are used inside `Transform` in _xmlseclibs_.