### PR TITLE
trim decrypted xml

### DIFF
--- a/src/Utils/Security.php
+++ b/src/Utils/Security.php
@@ -273,7 +273,7 @@ class Security
          */
         $xml = '<root xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ' .
                         'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' .
-            $decrypted . '</root>';
+            trim($decrypted) . '</root>';
 
         try {
             $newDoc = DOMDocumentFactory::fromString($xml);


### PR DESCRIPTION
trim decrypted xml to avoid decrypted element was not actually a DOMElement exception

when the assertion xml is start with a "\n",  $newDoc->firstChild->firstChild got a DOMText but not DOMElement, trim xml will fix this

Thanks @phelan for posting this fix in the saml2-repository