### PR TITLE
Add KeyTransport algo to EncryptionAlgorithmFactory

### DIFF
--- a/src/Alg/Encryption/EncryptionAlgorithmFactory.php
+++ b/src/Alg/Encryption/EncryptionAlgorithmFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SimpleSAML\XMLSecurity\Alg\Encryption;
 
 use SimpleSAML\XMLSecurity\Alg\AbstractAlgorithmFactory;
+use SimpleSAML\XMLSecurity\Alg\KeyTransport\RSA;
 use SimpleSAML\XMLSecurity\Constants as C;
 use SimpleSAML\XMLSecurity\Key\AbstractKey;
 
@@ -53,6 +54,7 @@ final class EncryptionAlgorithmFactory extends AbstractAlgorithmFactory
             [
                 TripleDES::class,
                 AES::class,
+                RSA::class,
             ],
         );
     }


### PR DESCRIPTION
Using the example from the README I was able to encrypt an element using `KEY_TRANSPORT_OAEP`, but when decrypting it again it would fail with a 'Unknown or unsupported algorithm' error.

This PR fixes this, but I'm not sure if it's the proper fix..