### PR TITLE
Bump to PHP 8.2 and leverage its new features

### DIFF
--- a/src/Backend/OpenSSL.php
+++ b/src/Backend/OpenSSL.php
@@ -15,6 +15,7 @@ use SimpleSAML\XMLSecurity\Utils\Random;
 use function chr;
 use function mb_strlen;
 use function openssl_cipher_iv_length;
+use function openssl_cipher_key_length;
 use function openssl_decrypt;
 use function openssl_encrypt;
 use function openssl_sign;
@@ -252,7 +253,7 @@ final class OpenSSL implements EncryptionBackend, SignatureBackend
             default:
                 $this->cipher = C::$BLOCK_CIPHER_ALGORITHMS[$cipher];
                 $this->blocksize = C::$BLOCK_SIZES[$cipher];
-                $this->keysize = C::$BLOCK_CIPHER_KEY_SIZES[$cipher];
+                $this->keysize = openssl_cipher_key_length(C::$BLOCK_CIPHER_ALGORITHMS[$cipher]);
         }
     }
 

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -217,17 +217,6 @@ class Constants extends \SimpleSAML\XML\Constants
         self::BLOCK_ENC_AES256_GCM => 16,
     ];
 
-    /** @var array<string, positive-int> */
-    public static array $BLOCK_CIPHER_KEY_SIZES = [
-        self::BLOCK_ENC_3DES => 24,
-        self::BLOCK_ENC_AES128 => 16,
-        self::BLOCK_ENC_AES192 => 24,
-        self::BLOCK_ENC_AES256 => 32,
-        self::BLOCK_ENC_AES128_GCM => 16,
-        self::BLOCK_ENC_AES192_GCM => 24,
-        self::BLOCK_ENC_AES256_GCM => 32,
-    ];
-
     /** @var array<string, string> */
     public static array $RSA_DIGESTS = [
         self::SIG_RSA_SHA1 => self::DIGEST_SHA1,
@@ -261,7 +250,7 @@ class Constants extends \SimpleSAML\XML\Constants
         self::C14N_INCLUSIVE_WITHOUT_COMMENTS,
         self::C14N_EXCLUSIVE_WITH_COMMENTS,
         self::C14N_EXCLUSIVE_WITHOUT_COMMENTS,
-//        self::C14N11_INCLUSIVE_WITH_COMMENTS,
-//        self::C14N11_INCLUSIVE_WITHOUT_COMMENTS,
+        self::C14N11_INCLUSIVE_WITH_COMMENTS,
+        self::C14N11_INCLUSIVE_WITHOUT_COMMENTS,
     ];
 }

--- a/src/Utils/Random.php
+++ b/src/Utils/Random.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\XMLSecurity\Utils;
 
-use Exception;
+use Random\RandomException;
 use SimpleSAML\Assert\Assert;
 use SimpleSAML\XMLSecurity\Exception\InvalidArgumentException;
 use SimpleSAML\XMLSecurity\Exception\RuntimeException;
@@ -43,7 +43,7 @@ class Random
             return random_bytes($length);
         } catch (ValueError) { // @phpstan-ignore-line
             throw new InvalidArgumentException('Invalid length received to generate random bytes.');
-        } catch (Exception) {
+        } catch (RandomException) {
             throw new RuntimeException(
                 'Cannot generate random bytes, no cryptographically secure random generator available.',
             );


### PR DESCRIPTION
- Replaces constants with new openssl-builtin `openssl_cipher_key_length`
- Replaces generic `Exception` with the more specific new `Random\RandomException`

Note: readonly properties cannot be used because of XML serialization